### PR TITLE
Fix url formatting for coordinates

### DIFF
--- a/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/ForecastRequestBuilder.java
+++ b/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/ForecastRequestBuilder.java
@@ -185,8 +185,8 @@ public class ForecastRequestBuilder {
 	}
 
 	forecastUrlString = forecastUrlString.replaceAll("##key##", apiKey.value())
-		.replaceAll("##latitude##", String.valueOf(geoCoordinates.latitude().value()))
-		.replaceAll("##longitude##", String.valueOf(geoCoordinates.longitude().value()))
+		.replaceAll("##latitude##", geoCoordinates.latitude().toString())
+		.replaceAll("##longitude##", geoCoordinates.longitude().toString())
 		.replaceAll("##time##", unixTimestamp)
 		+ requestParametersAsString();
 

--- a/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/ForecastRequestBuilder.java
+++ b/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/ForecastRequestBuilder.java
@@ -185,8 +185,8 @@ public class ForecastRequestBuilder {
 	}
 
 	forecastUrlString = forecastUrlString.replaceAll("##key##", apiKey.value())
-		.replaceAll("##latitude##", String.valueOf(geoCoordinates.latitude().toString()))
-		.replaceAll("##longitude##", String.valueOf(geoCoordinates.longitude().toString()))
+		.replaceAll("##latitude##", String.valueOf(geoCoordinates.latitude().value()))
+		.replaceAll("##longitude##", String.valueOf(geoCoordinates.longitude().value()))
 		.replaceAll("##time##", unixTimestamp)
 		+ requestParametersAsString();
 

--- a/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/model/Latitude.java
+++ b/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/model/Latitude.java
@@ -24,6 +24,7 @@
 package tk.plogitech.darksky.forecast.model;
 
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Objects;
 import static tk.plogitech.darksky.forecast.util.Assert.notNull;
 
@@ -72,7 +73,7 @@ public class Latitude implements Serializable {
      */
     @Override
     public String toString() {
-	return String.format("%f", value);
+	return String.format(Locale.ENGLISH, "%f", value);
     }
 
     @Override

--- a/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/model/Longitude.java
+++ b/darksky-forecast-api/src/main/java/tk/plogitech/darksky/forecast/model/Longitude.java
@@ -24,6 +24,7 @@
 package tk.plogitech.darksky.forecast.model;
 
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Objects;
 import static tk.plogitech.darksky.forecast.util.Assert.notNull;
 
@@ -72,7 +73,7 @@ public class Longitude implements Serializable {
      */
     @Override
     public String toString() {
-	return String.format("%f", value);
+	return String.format(Locale.ENGLISH, "%f", value);
     }
 
     @Override


### PR DESCRIPTION
The url formatting does not work on german systems, because the coordinates get formatted like `43,445664` instead of `43.445664`. That issues resulted in a bas request.